### PR TITLE
SEO Keyword is not a valid name

### DIFF
--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -34,7 +34,7 @@ class SeoData extends \craft\gql\base\ObjectType
                     'type' => Type::string(),
                 ],
                 'keywords' => Type::listOf(new ObjectType([
-                    'name' => 'SEO Keyword',
+                    'name' => 'Ether_SEOKeyword',
                     'fields' => ['keyword' => Type::string(), 'rating' => Type::string()]
                 ])),
                 'social' => SeoSocialNetworks::getType(),


### PR DESCRIPTION
Change name to Ether_SEOKeyword

Fixes # .

Changes proposed in this pull request:

- 
- 
- 