### PR TITLE
fix graphqltypes when running in production mode

### DIFF
--- a/src/Seo.php
+++ b/src/Seo.php
@@ -18,7 +18,10 @@ use craft\web\twig\variables\CraftVariable;
 use craft\web\UrlManager;
 use craft\web\View;
 use ether\seo\fields\SeoField;
+use ether\seo\gql\SeoAdvanced;
 use ether\seo\gql\SeoData;
+use ether\seo\gql\SeoSocialData;
+use ether\seo\gql\SeoSocialNetworks;
 use ether\seo\integrations\craftql\GetCraftQLSchema;
 use ether\seo\models\Settings;
 use ether\seo\services\RedirectsService;
@@ -114,8 +117,11 @@ class Seo extends Plugin
 		);
 
 		// GraphQL type
-        Event::on(Gql::class, Gql::EVENT_REGISTER_GQL_TYPES, function(RegisterGqlTypesEvent $event) {
+        Event::on(Gql::class, Gql::EVENT_REGISTER_GQL_TYPES, static function(RegisterGqlTypesEvent $event) {
             $event->types[] = SeoData::class;
+            $event->types[] = SeoAdvanced::class;
+            $event->types[] = SeoSocialData::class;
+            $event->types[] = SeoSocialNetworks::class;
         });
 
 		// Variable

--- a/src/gql/SeoAdvanced.php
+++ b/src/gql/SeoAdvanced.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ether\seo\gql;
+
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * Class SeoAdvanced
+ *
+ * @package ether\seo\gql
+ */
+class SeoAdvanced extends \craft\gql\base\ObjectType
+{
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
+    }
+
+    /**
+     * @return ObjectType
+     */
+    public static function getType(): ObjectType
+    {
+        if ($type = GqlEntityRegistry::getEntity(self::class)) {
+            return $type;
+        }
+
+        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
+            'name' => static::getName(),
+            'description' => 'Robots and canonical data',
+            'fields' => [
+                'robots' => Type::listOf(Type::string()),
+                'canonical' => Type::string()
+            ]
+        ]));
+    }
+}

--- a/src/gql/SeoData.php
+++ b/src/gql/SeoData.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace ether\seo\gql;
 
 use craft\gql\GqlEntityRegistry;
@@ -13,18 +16,24 @@ use craft\helpers\Gql;
  */
 class SeoData extends \craft\gql\base\ObjectType
 {
+    /**
+     * @return string
+     */
     public static function getName(): string
     {
         return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
     }
 
+    /**
+     * @return Type
+     */
     public static function getType(): Type
     {
-        if ($type = GqlEntityRegistry::getEntity(self::class)) {
+        if ($type = GqlEntityRegistry::getEntity(static::class)) {
             return $type;
         }
 
-        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
+        return GqlEntityRegistry::createEntity(static::class, new \GraphQL\Type\Definition\ObjectType([
             'name' => static::getName(),
             'fields' => [
                 'title' => [
@@ -39,124 +48,6 @@ class SeoData extends \craft\gql\base\ObjectType
                 ])),
                 'social' => SeoSocialNetworks::getType(),
                 'advanced' => SeoAdvanced::getType(),
-            ]
-        ]));
-    }
-}
-
-/**
- * Class SeoSocialNetworks
- * @package ether\seo\gql
- */
-class SeoSocialNetworks extends \craft\gql\base\ObjectType
-{
-    public static function getName(): string
-    {
-        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
-    }
-
-    public static function getType(): ObjectType {
-        if ($type = GqlEntityRegistry::getEntity(self::class)) {
-            return $type;
-        }
-
-        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
-            'name' => static::getName(),
-            'fields' => [
-                'twitter' => SeoSocialData::getType(),
-                'facebook' => SeoSocialData::getType()
-            ]
-        ]));
-    }
-
-}
-
-/**
- * Class SeoSocialData
- * @package ether\seo\gql
- */
-class SeoSocialData extends \craft\gql\base\ObjectType
-{
-    public static function getName(): string
-    {
-        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
-    }
-
-    /**
-     * @return ObjectType
-     * @throws \craft\errors\GqlException
-     */
-    public static function getType(): ObjectType {
-        if ($type = GqlEntityRegistry::getEntity(self::class)) {
-            return $type;
-        }
-
-        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
-            'name' => static::getName(),
-            'description' => 'Social data for an individual Social network',
-            'fields' => array_merge(self::getConditionalFields(), [
-                'title' => [
-                    'type' => Type::string(),
-                ],
-                'description' => [
-                    'type' => Type::string(),
-                ]
-            ])
-        ]));
-    }
-
-    /**
-     * Get fields which may only be used depending on the craft Gql config
-     * @throws \craft\errors\GqlException
-     */
-    protected static function getConditionalFields(): array
-    {
-        // Images may be in any public volume, so verify them all.
-        $volumes = \Craft::$app->volumes->getPublicVolumes();
-        $awareOfAllPublicVolumes = false;
-
-        if (!empty($volumes)) {
-            foreach ($volumes as $volume) {
-                if (!Gql::isSchemaAwareOf('volumes.' . $volume->uid)) {
-                    $awareOfAllPublicVolumes = false;
-                    break;
-                }
-
-                $awareOfAllPublicVolumes = true;
-            }
-        }
-
-        if ($awareOfAllPublicVolumes) {
-            return [
-                'image' => [
-                    'name' => 'image',
-                    'type' => AssetInterface::getType(),
-                ]
-            ];
-        }
-        return [];
-    }
-}
-
-class SeoAdvanced extends \craft\gql\base\ObjectType
-{
-    public static function getName(): string
-    {
-        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
-    }
-
-    public static function getType(): ObjectType
-    {
-        if ($type = GqlEntityRegistry::getEntity(self::class)) {
-            return $type;
-        }
-
-        return GqlEntityRegistry::createEntity(self::class, new \GraphQL\Type\Definition\ObjectType([
-            'name' => static::getName(),
-            'description' => 'Robots and canonical data',
-            'fields' => [
-                'robots' => Type::listOf(Type::string()),
-                'canonical' => Type::string()
             ]
         ]));
     }

--- a/src/gql/SeoSocialData.php
+++ b/src/gql/SeoSocialData.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ether\seo\gql;
+
+use craft\gql\GqlEntityRegistry;
+use craft\gql\interfaces\elements\Asset as AssetInterface;
+use craft\helpers\Gql;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+
+/**
+ * Class SeoSocialData
+ *
+ * @package ether\seo\gql
+ */
+class SeoSocialData extends \craft\gql\base\ObjectType
+{
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
+    }
+
+    /**
+     * @return ObjectType
+     * @throws \craft\errors\GqlException
+     */
+    public static function getType(): ObjectType
+    {
+        if ($type = GqlEntityRegistry::getEntity(static::class)) {
+            return $type;
+        }
+
+        return GqlEntityRegistry::createEntity(static::class, new \GraphQL\Type\Definition\ObjectType([
+            'name' => static::getName(),
+            'description' => 'Social data for an individual Social network',
+            'fields' => array_merge(static::getConditionalFields(), [
+                'title' => [
+                    'type' => Type::string(),
+                ],
+                'description' => [
+                    'type' => Type::string(),
+                ]
+            ])
+        ]));
+    }
+
+    /**
+     * Get fields which may only be used depending on the craft Gql config
+     *
+     * @throws \craft\errors\GqlException
+     */
+    protected static function getConditionalFields(): array
+    {
+        // Images may be in any public volume, so verify them all.
+        $volumes = \Craft::$app->volumes->getPublicVolumes();
+        $awareOfAllPublicVolumes = false;
+
+        if (!empty($volumes)) {
+            foreach ($volumes as $volume) {
+                if (!Gql::isSchemaAwareOf('volumes.' . $volume->uid)) {
+                    $awareOfAllPublicVolumes = false;
+                    break;
+                }
+
+                $awareOfAllPublicVolumes = true;
+            }
+        }
+
+        if ($awareOfAllPublicVolumes) {
+            return [
+                'image' => [
+                    'name' => 'image',
+                    'type' => AssetInterface::getType(),
+                ]
+            ];
+        }
+
+        return [];
+    }
+}

--- a/src/gql/SeoSocialNetworks.php
+++ b/src/gql/SeoSocialNetworks.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ether\seo\gql;
+
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\ObjectType;
+
+/**
+ * Class SeoSocialNetworks
+ *
+ * @package ether\seo\gql
+ */
+class SeoSocialNetworks extends \craft\gql\base\ObjectType
+{
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return "Ether_" . (new \ReflectionClass(static::class))->getShortName();
+    }
+
+    /**
+     * @return ObjectType
+     * @throws \craft\errors\GqlException
+     */
+    public static function getType(): ObjectType
+    {
+        if ($type = GqlEntityRegistry::getEntity(static::class)) {
+            return $type;
+        }
+
+        return GqlEntityRegistry::createEntity(static::class, new \GraphQL\Type\Definition\ObjectType([
+            'name' => static::getName(),
+            'fields' => [
+                'twitter' => SeoSocialData::getType(),
+                'facebook' => SeoSocialData::getType()
+            ]
+        ]));
+    }
+}


### PR DESCRIPTION
The graphQL types were not correctly registered when running without devmode=true.

This fixes that and also adds strict mode to all the GQL code.